### PR TITLE
Add Eclipse '.metadata' directory to ignore list

### DIFF
--- a/psslib/driver.py
+++ b/psslib/driver.py
@@ -143,7 +143,7 @@ IGNORED_DIRS = set([
     'blib', '_build', '.bzr', '.cdv', 'cover_db', '__pycache__',
     'CVS', '_darcs', '~.dep', '~.dot', '.git', '.hg', '~.nib',
     '.pc', '~.plst', 'RCS', 'SCCS', '_sgbak', '.svn', '.tox',
-	'.metadata'])
+    '.metadata'])
 
 IGNORED_FILE_PATTERNS = set([r'~$', r'#.+#$', r'[._].*\.swp$', r'core\.\d+$'])
 


### PR DESCRIPTION
Eclipse's `.metadata` directory is located below the workspace. It contains the `.plugin` subdirectory, which has a lot of code in it - both plugin code and file history from the workspace.

For example, when I `pss`-ed for `connectURI` in my workspace, I got one correct result and a few dozen results from the history in `.metadata`:

```
./.metadata/.plugins/org.eclipse.core.resources/.history/bc/70d26d74bbfe00121178f4cf4000aacf
23: private static final String connectURI  =   "...jdbcCompliantTruncation=false";
48:             connection = DriverManager.getConnection(connectURI, username, password);
53:                     connectURI, username, password, e.getMessage());

./.metadata/.plugins/org.eclipse.core.resources/.history/c1/80554931e62f0013154c9564f9925bf1
23: private static final String connectURI  =   "jdbc:mysql://127.0.0.1:3306/pixels?    jdbcCompliantTruncation=false";
48:             connection = DriverManager.getConnection(connectURI, username, password);
50:                     connection.toString(), connectURI, username));
54:                     connectURI, username, password, e.getMessage());

...
```

I assume that most users would like to view the code in their workspace, rather than Eclipse's plugin and history folders.
