### PR TITLE
If setuptools is available, use entry points for the pss executable rather than a hand-crafted script.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [wheel]
+# When generating a wheel, mark it as suitable for any version of Python,
+# rather than only for the Python version used to build the wheel.
 universal=1

--- a/setup.py
+++ b/setup.py
@@ -15,12 +15,19 @@ except ImportError:
     use_setuptools = False
 
 if use_setuptools:
+    # Setuptools provides an "entry points" facility to automatically generate
+    # scripts that work in the same way as the supplied "pss" script. This
+    # feature is more portable to other platforms than providing a manually
+    # created script, so we use that feature if it is available.
+    # By using entry points, we get a "pss" shell script on Unix, and a
+    # "pss.exe" command on Windows, without any extra effort.
     extra_args = {
         'entry_points': {
             'console_scripts': 'pss = psslib.pss:main'
         },
     }
 else:
+    # Setuptools is not available, so fall back to custom built scripts.
     extra_args = {
         'scripts': ['scripts/pss.py', 'scripts/pss'],
     }


### PR DESCRIPTION
This is useful on Windows, where the scripts are not as robust as using an exe wrapper. The patch only uses entry points if setuptools is available at build time.

If a wheel is generated, and pip 1.5 is used to install the wheel, the executable wrapper does not depend on setuptools. If an install from source is done, the wrappers generated by setuptools rely on pkg_resources at runtime (but in this case, the fact that the install used setuptools means that setuptools _will_ be available at runtime). This latter is a setuptools limitation.
