### PR TITLE
Exit with a return code similarly as ack and grep.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,6 +11,8 @@ Changelog
     distribution for Windows (pull request #18)
   - Added Bash completion script in tools/pss-bash-completion.bash, along with a
     special option for pss to dump the list of types for it.
+  - Exit with a return code similarly as ack and grep (issue #24).
+    0: Match found or help/version printed. 1: No match. 2: Error.
 
 + Version 1.39 (20.09.2013)
 

--- a/psslib/driver.py
+++ b/psslib/driver.py
@@ -192,10 +192,13 @@ def pss_run(roots,
         ncontext_after=0,
         ):
     """ The main pss invocation function - handles all PSS logic.
+
         For documentation of options, see the --help output of the pss script,
         and study how its command-line arguments are parsed and passed to
         this function. Besides, most options are passed verbatim to submodules
         and documented there. I don't like to repeat myself too much :-)
+
+        Returns True/False depending was match found or not.
     """
     # Set up a default output formatter, if none is provided
     #
@@ -275,6 +278,8 @@ def pss_run(roots,
             literal_pattern=literal_pattern,
             max_match_count=max_match_count)
 
+    match_found = False
+
     # All systems go...
     #
     for filepath in filefinder.files():
@@ -283,6 +288,7 @@ def pss_run(roots,
         if (    only_find_files and
                 only_find_files_option == PssOnlyFindFilesOption.ALL_FILES):
             output_formatter.found_filename(filepath)
+            match_found = True
             continue
         # The main path: do matching inside the file.
         # Some files appear to be binary - they are not of a known file type
@@ -300,6 +306,7 @@ def pss_run(roots,
                     if matches:
                         output_formatter.binary_file_matches(
                                 'Binary file %s matches\n' % filepath)
+                        match_found = True
                     continue
                 # istextfile does some reading on fileobj, so rewind it
                 fileobj.seek(0)
@@ -315,6 +322,7 @@ def pss_run(roots,
                             only_find_files_option == PssOnlyFindFilesOption.FILES_WITHOUT_MATCHES))
                     if found:
                         output_formatter.found_filename(filepath)
+                        match_found = True
                     continue
 
                 # This is the "normal path" when we examine and display the
@@ -323,6 +331,7 @@ def pss_run(roots,
                 if not matches:
                     # Nothing to see here... move along
                     continue
+                match_found =True
                 output_formatter.start_matches_in_file(filepath)
                 if ncontext_before > 0 or ncontext_after > 0:
                     # If context lines should be printed, we have to read in the
@@ -366,6 +375,9 @@ def pss_run(roots,
         except (OSError, IOError):
             # There was a problem opening or reading the file, so ignore it.
             pass
+
+    return match_found
+
 
 def _pattern_has_uppercase(pattern):
     """ Check whether the given regex pattern has uppercase letters to match

--- a/psslib/py3compat.py
+++ b/psslib/py3compat.py
@@ -22,6 +22,7 @@ identity_func = lambda x: x
 # in py2.
 #
 if PY3:
+    from io import StringIO
     def str2bytes(s):
         return s.encode('latin1')
     def int2byte(i):
@@ -29,6 +30,7 @@ if PY3:
     def bytes2str(b):
         return b.decode('utf-8')
 else:
+    from StringIO import StringIO
     str2bytes = identity_func
     int2byte = chr
     bytes2str = identity_func
@@ -41,4 +43,3 @@ def tostring(b):
         return bytes2str(b)
     else:
         return b
-

--- a/scripts/pss
+++ b/scripts/pss
@@ -1,3 +1,4 @@
 #!/usr/bin/env python
-from psslib.pss import main; main()
-
+import sys
+from psslib.pss import main
+sys.exit(main())

--- a/scripts/pss.py
+++ b/scripts/pss.py
@@ -1,3 +1,4 @@
 #!/usr/bin/env python
-from psslib.pss import main; main()
-
+import sys
+from psslib.pss import main
+sys.exit(main())

--- a/test/test_driver.py
+++ b/test/test_driver.py
@@ -18,7 +18,7 @@ class TestDriver(unittest.TestCase):
         self.of = MockOutputFormatter('testdir1')
 
     def test_basic(self):
-        pss_run(
+        match_found = pss_run(
             roots=[self.testdir1],
             pattern='abc',
             output_formatter=self.of,
@@ -29,6 +29,8 @@ class TestDriver(unittest.TestCase):
                     'testdir1/filea.c', [('MATCH', (2, [(4, 7)]))]) +
                 self._gen_outputs_in_file(
                     'testdir1/filea.h', [('MATCH', (1, [(8, 11)]))])))
+
+        self.assertEquals(match_found, True)
 
     def _gen_outputs_in_file(self, filename, outputs):
         """ Helper method for constructing a list of output pairs in the format

--- a/test/test_pssmain.py
+++ b/test/test_pssmain.py
@@ -12,6 +12,7 @@ import unittest
 sys.path.insert(0, '.')
 sys.path.insert(0, '..')
 from psslib.pss import main
+from psslib.py3compat import StringIO
 from test.utils import (
         path_to_testdir, MockOutputFormatter, filter_out_path)
 
@@ -263,7 +264,7 @@ class TestPssMain(unittest.TestCase):
                 ['testdir1/subdir1/filey.c'])
 
         self.of = MockOutputFormatter('testdir1')
-        self._run_main(['-g', r'\.qqq'])
+        self._run_main(['-g', r'\.qqq'], expected_rc=1)
         self.assertFoundFiles(self.of, [])
 
         self.of = MockOutputFormatter('testdir1')
@@ -292,7 +293,7 @@ class TestPssMain(unittest.TestCase):
         # .rb files have some weird characters in them - this is a sanity
         # test that shows that pss won't crash while decoding these files
         #
-        self._run_main(['ttt', '--ruby'])
+        self._run_main(['ttt', '--ruby'], expected_rc=1)
 
     def test_include_types(self):
         rootdir = path_to_testdir('test_types')
@@ -356,10 +357,32 @@ class TestPssMain(unittest.TestCase):
                 self._gen_outputs_in_file(
                     'testdir1/filea.h', [('MATCH', (1, [(8, 11)]))])))
 
-    def _run_main(self, args, dir=None, output_formatter=None):
-        main(
+    def test_return_code(self):
+        # 0: match found or help/version printed
+        # 1: no match
+        # 2: error
+        sys.stdout = StringIO()  # help is not printed through output_formatter
+        sys.stderr = StringIO()  # errors by optparse go here
+        try:
+            for args, expected in [(['--help'], 0),
+                                   (['--version'], 0),
+                                   ([], 0),  # prints help
+                                   (['abc', self.testdir1], 0),
+                                   (['--py', 'abc', self.testdir1], 1),
+                                   (['no match here', self.testdir1], 1),
+                                   (['--invalid'], 2),
+                                   ([['invalid arg causes error']], 2)]:
+                rc = main(['pss'] + args, output_formatter=self.of)
+                self.assertEquals(rc, expected)
+        finally:
+            sys.stdout = sys.__stdout__
+            sys.stderr = sys.__stderr__
+
+    def _run_main(self, args, dir=None, output_formatter=None, expected_rc=0):
+        rc = main(
             argv=[''] + args + [dir or self.testdir1],
             output_formatter=output_formatter or self.of)
+        self.assertEquals(rc, expected_rc)
 
     def _gen_outputs_in_file(self, filename, outputs, add_end=True):
         """ Helper method for constructing a list of output pairs in the format


### PR DESCRIPTION
Exit with a return code similarly as ack and grep.

0: Match found or help/version printed.
1: No match.
2: Error.

Also changed `main()` not to call `sys.exit()` but to return the rc.

Resolves #24.
