### PR TITLE
Add optional support for PEP278 universal newlines

### DIFF
--- a/psslib/driver.py
+++ b/psslib/driver.py
@@ -198,6 +198,7 @@ def pss_run(roots,
         do_heading=True,
         prefix_filename_to_file_matches=True,
         show_column_of_first_match=False,
+        universal_newlines=False,
         ncontext_before=0,
         ncontext_after=0,
         ):
@@ -271,10 +272,14 @@ def pss_run(roots,
     # Set up the content matcher
     #
 
-    if pattern is None:
-        pattern = b''
+    if universal_newlines:
+        if pattern is None:
+            pattern = ''
     else:
-        pattern = str2bytes(pattern)
+        if pattern is None:
+            pattern = b''
+        else:
+            pattern = str2bytes(pattern)
 
     if (    not ignore_case and
             (smart_case and not _pattern_has_uppercase(pattern))):
@@ -308,7 +313,8 @@ def pss_run(roots,
         # full work.
         #
         try:
-            with open(filepath, 'rb') as fileobj:
+            openmode = 'rU' if universal_newlines else 'rb'
+            with open(filepath, openmode) as fileobj:
                 if not istextfile(fileobj):
                     # istextfile does some reading on fileobj, so rewind it
                     fileobj.seek(0)

--- a/psslib/pss.py
+++ b/psslib/pss.py
@@ -142,6 +142,7 @@ def main(argv=sys.argv, output_formatter=None):
                 do_heading=options.do_heading,
                 prefix_filename_to_file_matches=options.prefix_filename,
                 show_column_of_first_match=options.show_column,
+                universal_newlines=options.universal_newlines,
                 ncontext_before=ncontext_before,
                 ncontext_after=ncontext_after)
     except KeyboardInterrupt:
@@ -240,6 +241,9 @@ def parse_cmdline(cmdline_args):
     group_searching.add_option('-Q', '--literal',
         action='store_true', dest='literal', default=False,
         help='Quote all metacharacters; the pattern is literal')
+    group_searching.add_option('-U', '--universal-newlines',
+        action='store_true', dest='universal_newlines', default=False,
+        help='Use PEP 278 universal newline support when opening files')
     optparser.add_option_group(group_searching)
 
     group_output = optparse.OptionGroup(optparser, 'Search output')

--- a/psslib/utils.py
+++ b/psslib/utils.py
@@ -6,7 +6,7 @@
 # Eli Bendersky (eliben@gmail.com)
 # This code is in the public domain
 #-------------------------------------------------------------------------------
-from .py3compat import int2byte
+from .py3compat import int2byte, str2bytes
 from . import colorama
 
 
@@ -21,6 +21,12 @@ def istextfile(fileobj, blocksize=512):
         are NUL ('\x00') bytes in the block, assume this is a binary file.
     """
     block = fileobj.read(blocksize)
+
+    # With -U the file will be open in text mode,
+    # so a read (in python 3) won't return bytes.
+    if not isinstance(block, bytes):
+        block = str2bytes(block)
+
     if b'\x00' in block:
         # Files with null bytes are binary
         return False

--- a/test/test_pssmain.py
+++ b/test/test_pssmain.py
@@ -289,6 +289,14 @@ class TestPssMain(unittest.TestCase):
         self.assertEqual(binary_match[0], 'BINARY_MATCH')
         self.assertTrue(binary_match[1].find('zb.erl') > 0)
 
+    def test_binary_matches_universal_newlines(self):
+        # make sure -U doesn't break binary matching
+        self._run_main(['-U', '-G', 'zb', 'cde'])
+
+        binary_match = self.of.output[-1]
+        self.assertEqual(binary_match[0], 'BINARY_MATCH')
+        self.assertTrue(binary_match[1].find('zb.erl') > 0)
+
     def test_weird_chars(self):
         # .rb files have some weird characters in them - this is a sanity
         # test that shows that pss won't crash while decoding these files
@@ -377,6 +385,21 @@ class TestPssMain(unittest.TestCase):
         finally:
             sys.stdout = sys.__stdout__
             sys.stderr = sys.__stderr__
+
+    def test_universal_newlines(self):
+        of = MockOutputFormatter('testdir3')
+        self._run_main(['-U', '--match=test$'],
+                       dir=path_to_testdir('testdir3'),
+                       output_formatter=of)
+        self.assertEqual(sorted(of.output),
+                         sorted(
+                             self._gen_outputs_in_file(
+                                'testdir3/lfnewlines.txt', [('MATCH', (1, [(10, 14)]))]) +
+                             self._gen_outputs_in_file(
+                                'testdir3/crlfnewlines.txt', [('MATCH', (1, [(10, 14)]))]) +
+                             self._gen_outputs_in_file(
+                                'testdir3/crnewlines.txt', [('MATCH', (1, [(10, 14)]))])
+                         ))
 
     def _run_main(self, args, dir=None, output_formatter=None, expected_rc=0):
         rc = main(

--- a/test/testdirs/testdir3/.gitattributes
+++ b/test/testdirs/testdir3/.gitattributes
@@ -1,0 +1,2 @@
+# preserve original newline encoding of theses:
+*newlines.txt -text

--- a/test/testdirs/testdir3/crlfnewlines.txt
+++ b/test/testdirs/testdir3/crlfnewlines.txt
@@ -1,0 +1,3 @@
+This is a test
+of a file with CRLF line endings.
+

--- a/test/testdirs/testdir3/crnewlines.txt
+++ b/test/testdirs/testdir3/crnewlines.txt
@@ -1,0 +1,1 @@
+This is a testof a file with CR line endings.

--- a/test/testdirs/testdir3/lfnewlines.txt
+++ b/test/testdirs/testdir3/lfnewlines.txt
@@ -1,0 +1,3 @@
+This is a test
+of a file with LF line endings.
+


### PR DESCRIPTION
A new argument (-U, --universal-newlines) makes
pss open files with the U flag, which makes python
auto-detect the files' newlines format. Especially
useful for searching MacOS files which have CR
only newlines.