### PR TITLE
Improve option parsing.

### DIFF
--- a/psslib/pss.py
+++ b/psslib/pss.py
@@ -9,7 +9,7 @@
 #-------------------------------------------------------------------------------
 from __future__ import print_function
 import os, sys
-import optparse
+import argparse
 
 
 from psslib import __version__
@@ -32,11 +32,9 @@ def main(argv=sys.argv, output_formatter=None):
             0: Match found or help/version printed. 1: No match. 2: Error.
     """
     try:
-        options, args, optparser = parse_cmdline(argv[1:])
-    except VersionPrinted:
-        return 0
-    except SystemExit:
-        return 2
+        options, args, argparser = parse_cmdline(argv[1:])
+    except SystemExit as exc:
+        return exc.code
 
     # Handle the various "only find files" options.
     #
@@ -72,7 +70,7 @@ def main(argv=sys.argv, output_formatter=None):
         show_type_list()
         return 0
     elif (len(args) == 0 and search_pattern_expected) or options.help:
-        optparser.print_help()
+        argparser.print_help()
         print(DESCRIPTION_AFTER_USAGE)
         return 0
 
@@ -156,15 +154,14 @@ def main(argv=sys.argv, output_formatter=None):
 
 
 DESCRIPTION = r'''
-Search for the pattern in each source file, starting with the
-current directory and its sub-directories, recursively. If
-[files] are specified, only these files/directories are searched.
+Search for the pattern in each source file, starting with the current
+directory and its sub-directories, recursively. If [files] are specified,
+only these files/directories are searched.
 
-Only files with known extensions are searched, and this can be
-configured by providing --<type> options. For example, --python
-will search all Python files, and "--lisp --scheme" will search
-all Lisp and all Scheme files. By default, all known file types
-are searched.
+Only files with known extensions are searched, and this can be configured
+by providing --<type> options. For example, --python will search all Python
+files, and "--lisp --scheme" will search all Lisp and all Scheme files. By
+default, all known file types are searched.
 
 Run with --help-types for more help on how to select file types.
 '''.lstrip()
@@ -179,7 +176,7 @@ def _ignored_dirs_as_string():
     return ' '.join(s)
 
 
-DESCRIPTION_AFTER_USAGE = r'''
+DESCRIPTION_AFTER_USAGE = r"""
 By default, the following directories and everything below them is
 ignored:
 
@@ -193,8 +190,21 @@ Additionally, files matching these (regexp) patterns are ignored:
 
       %s
 
+Options may also be specified by putting them in a file, and referring to
+the file on the command line using '@'.  Options and their arguments appear
+in the file one per line.  Blank lines and comments (starting with #) are
+ignored.  For example, if you have a file called 'options.cfg'...
+
+      # My pss options file.
+
+      --no-filename
+      --ignore-dir temp
+
+you can set the options using 'pss @options.cfg'.  Option files and other
+options may be mixed.
+
 pss version %s
-''' % ( _ignored_dirs_as_string(),
+""" % ( _ignored_dirs_as_string(),
         '\n      '.join(IGNORED_FILE_PATTERNS),
         __version__,)
 
@@ -202,173 +212,190 @@ pss version %s
 def parse_cmdline(cmdline_args):
     """ Parse the list of command-line options and arguments and return a
         triple: options, args, parser -- the first two being the result of
-        OptionParser.parse_args, and the third the parser object itself.`
+        ArgumentParser.parse_known_args, and the third the parser object
+        itself.
     """
-    optparser = PssOptionParser(
-        usage='usage: %prog [options] <pattern> [files]',
-        description=DESCRIPTION,
-        prog='pss',
-        add_help_option=False,  # -h is a real option
-        version='pss %s' % __version__)
 
-    optparser.add_option('--help-types',
+    argparser = PssArgumentParser(
+        usage='%(prog)s [options] <pattern> [files]',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=DESCRIPTION,
+        fromfile_prefix_chars='@',
+        prog='pss',
+        add_help=False)  # -h is a real option
+
+    group_options = argparser.add_argument_group('Options')
+    group_options.add_argument('--help',
+        action='store_true',
+        help='Display this information')
+    group_options.add_argument('--help-types',
         action='store_true', dest='help_types',
         help='Display supported file types')
-    optparser.add_option('--help',
-        action='store_true', dest='help',
-        help='Display this information')
+    group_options.add_argument('--version',
+        action='version', version='pss %s' % __version__,
+        help="Show program's version number and exit")
 
     # This option is for internal usage by the bash completer, so we're hiding
     # it from the --help output
-    optparser.add_option('--show-type-list',
+    argparser.add_argument('--show-type-list',
         action='store_true', dest='show_type_list',
-        help=optparse.SUPPRESS_HELP)
+        help=argparse.SUPPRESS)
 
-    group_searching = optparse.OptionGroup(optparser, 'Searching')
-    group_searching.add_option('-i', '--ignore-case',
+    group_searching = argparser.add_argument_group('Searching')
+    group_searching.add_argument('-i', '--ignore-case',
         action='store_true', dest='ignore_case', default=False,
         help='Ignore case distinctions in the pattern')
-    group_searching.add_option('--smart-case',
+    group_searching.add_argument('--smart-case',
         action='store_true', dest='smart_case', default=False,
         help='Ignore case distinctions in the pattern, only if the pattern '
         'contains no upper case. Ignored if -i is specified')
-    group_searching.add_option('-v', '--invert-match',
+    group_searching.add_argument('-v', '--invert-match',
         action='store_true', dest='invert_match', default=False,
         help='Invert match: show non-matching lines')
-    group_searching.add_option('-w', '--word-regexp',
+    group_searching.add_argument('-w', '--word-regexp',
         action='store_true', dest='word_regexp', default=False,
         help='Force the pattern to match only whole words')
-    group_searching.add_option('-Q', '--literal',
+    group_searching.add_argument('-Q', '--literal',
         action='store_true', dest='literal', default=False,
         help='Quote all metacharacters; the pattern is literal')
-    group_searching.add_option('-U', '--universal-newlines',
+    group_searching.add_argument('-U', '--universal-newlines',
         action='store_true', dest='universal_newlines', default=False,
         help='Use PEP 278 universal newline support when opening files')
-    optparser.add_option_group(group_searching)
+    argparser.add_argument_group(group_searching)
 
-    group_output = optparse.OptionGroup(optparser, 'Search output')
-    group_output.add_option('--match',
+    group_output = argparser.add_argument_group('Search output')
+    group_output.add_argument('--match',
         action='store', dest='match', metavar='PATTERN',
         help='Specify the search pattern explicitly')
-    group_output.add_option('-m', '--max-count',
+    group_output.add_argument('-m', '--max-count',
         action='store', dest='max_count', metavar='NUM', default=sys.maxsize,
-        type='int', help='Stop searching in each file after NUM matches')
-    group_output.add_option('-H', '--with-filename',
+        type=int, help='Stop searching in each file after NUM matches')
+    group_output.add_argument('-H', '--with-filename',
         action='store_true', dest='prefix_filename', default=True,
         help=' '.join(r'''Print the filename before matches (default). If
         --noheading is specified, the filename will be prepended to each
         matching line. Otherwise it is printed once for all the matches
         in the file.'''.split()))
-    group_output.add_option('-h', '--no-filename',
+    group_output.add_argument('-h', '--no-filename',
         action='store_false', dest='prefix_filename',
         help='Suppress printing the filename before matches')
-    group_output.add_option('--column',
+    group_output.add_argument('--column',
         action='store_true', dest='show_column',
         help='Show the column number of the first match')
-    group_output.add_option('-A', '--after-context',
+    group_output.add_argument('-A', '--after-context',
         action='store', dest='after_context', metavar='NUM', default=0,
-        type='int', help='Print NUM lines of context after each match')
-    group_output.add_option('-B', '--before-context',
+        type=int, help='Print NUM lines of context after each match')
+    group_output.add_argument('-B', '--before-context',
         action='store', dest='before_context', metavar='NUM', default=0,
-        type='int', help='Print NUM lines of context before each match')
-    group_output.add_option('-C', '--context',
-        action='store', dest='context', metavar='NUM', type='int',
+        type=int, help='Print NUM lines of context before each match')
+    group_output.add_argument('-C', '--context',
+        action='store', dest='context', metavar='NUM', type=int,
         help='Print NUM lines of context before and after each match')
-    group_output.add_option('--color',
+    group_output.add_argument('--color',
         action='store_true', dest='do_colors', default=sys.stdout.isatty(),
         help='Highlight the matching text')
-    group_output.add_option('--nocolor',
+    group_output.add_argument('--nocolor',
         action='store_false', dest='do_colors',
         help='Do not highlight the matching text (this is the default when output is redirected)')
-    group_output.add_option('--color-match', metavar='FORE,BACK,STYLE',
+    group_output.add_argument('--color-match', metavar='FORE,BACK,STYLE',
         action='store', dest='color_match',
         help='Set the color for matches')
-    group_output.add_option('--color-filename', metavar='FORE,BACK,STYLE',
+    group_output.add_argument('--color-filename', metavar='FORE,BACK,STYLE',
         action='store', dest='color_filename',
         help='Set the color for emitted filenames')
-    group_output.add_option('--color-lineno', metavar='FORE,BACK,STYLE',
+    group_output.add_argument('--color-lineno', metavar='FORE,BACK,STYLE',
         action='store', dest='color_lineno',
         help='Set the color for line numbers')
-    group_output.add_option('--nobreak',
+    group_output.add_argument('--nobreak',
         action='store_false', dest='do_break', default=sys.stdout.isatty(),
         help='Print no break between results from different files')
-    group_output.add_option('--noheading',
+    group_output.add_argument('--noheading',
         action='store_false', dest='do_heading', default=sys.stdout.isatty(),
         help="Print no file name heading above each file's results")
-    optparser.add_option_group(group_output)
 
-    group_filefinding = optparse.OptionGroup(optparser, 'File finding')
-    group_filefinding.add_option('-f',
+    group_filefinding = argparser.add_argument_group('File finding')
+    group_filefinding.add_argument('-f',
         action='store_true', dest='find_files',
         help='Only print the names of found files. The pattern must not be specified')
-    group_filefinding.add_option('-g',
+    group_filefinding.add_argument('-g',
         action='store', dest='find_files_matching_pattern', metavar='REGEX',
         help='Same as -f, but only print files matching REGEX')
-    group_filefinding.add_option('-l', '--files-with-matches',
+    group_filefinding.add_argument('-l', '--files-with-matches',
         action='store_true', dest='find_files_with_matches',
         help='Only print the names of found files that have matches for the pattern')
-    group_filefinding.add_option('-L', '--files-without-matches',
+    group_filefinding.add_argument('-L', '--files-without-matches',
         action='store_true', dest='find_files_without_matches',
         help='Only print the names of found files that have no matches for the pattern')
-    optparser.add_option_group(group_filefinding)
 
-    group_inclusion = optparse.OptionGroup(optparser, 'File inclusion/exclusion')
-    group_inclusion.add_option('-a', '--all-types',
+    group_inclusion = argparser.add_argument_group('File inclusion/exclusion')
+    group_inclusion.add_argument('-a', '--all-types',
         action='store_true', dest='all_types',
         help='All file types are searched')
-    group_inclusion.add_option('-u', '--unrestricted',
+    group_inclusion.add_argument('-u', '--unrestricted',
         action='store_true', dest='unrestricted',
         help='All files are searched, including those in ignored directories')
-    group_inclusion.add_option('--ignore-dir',
+    group_inclusion.add_argument('--ignore-dir',
         action='append', dest='ignored_dirs', metavar='name',
         help='Add directory to the list of ignored dirs')
-    group_inclusion.add_option('--noignore-dir',
+    group_inclusion.add_argument('--noignore-dir',
         action='append', dest='noignored_dirs', metavar='name',
         help='Remove directory from the list of ignored dirs')
-    group_inclusion.add_option('-r', '-R', '--recurse',
+    group_inclusion.add_argument('-r', '-R', '--recurse',
         action='store_true', dest='recurse', default=True,
         help='Recurse into subdirectories (default)')
-    group_inclusion.add_option('-n', '--no-recurse',
+    group_inclusion.add_argument('-n', '--no-recurse',
         action='store_false', dest='recurse',
         help='Do not recurse into subdirectories')
-    group_inclusion.add_option('-t', '--textonly', '--nobinary',
+    group_inclusion.add_argument('-t', '--textonly', '--nobinary',
         action='store_true', dest='textonly', default=False,
         help='''Restrict the search to only textual files.
         Warning: with this option the search is likely to run much slower''')
-    group_inclusion.add_option('-G',
+    group_inclusion.add_argument('-G',
         action='store', dest='type_pattern', metavar='REGEX',
         help='Only search files that match REGEX')
-    optparser.add_option_group(group_inclusion)
 
     # Parsing --<type> and --no<type> options for all supported types is
-    # done with a callback action. The callback function stores a list
-    # of all type options in the typelist attribute of the options.
+    # done with a custom action.  The action stores a list of all type
+    # options in the namespace of the options.
     #
-    def type_option_callback(option, opt_str, value, parser):
-        optname = opt_str.lstrip('-')
-        if hasattr(parser.values, 'typelist'):
-            parser.values.typelist.append(optname)
-        else:
-            parser.values.typelist = [optname]
+    class TypeAction(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string):
+            name = option_string.lstrip('-')
+            if hasattr(namespace, 'typelist'):
+                namespace.typelist.append(name)
+            else:
+                namespace.typelist = [name]
 
     for t in TYPE_MAP:
-        optparser.add_option('--' + t,
-            help=optparse.SUPPRESS_HELP,
-            action='callback',
-            callback=type_option_callback)
-        optparser.add_option('--no' + t,
-            help=optparse.SUPPRESS_HELP,
-            action='callback',
-            callback=type_option_callback)
+        argparser.add_argument('--' + t,
+            nargs=0,
+            help=argparse.SUPPRESS,
+            action=TypeAction)
+        argparser.add_argument('--no' + t,
+            nargs=0,
+            help=argparse.SUPPRESS,
+            action=TypeAction)
 
-    options, args = optparser.parse_args(cmdline_args)
-    return options, args, optparser
+    # Parse known arguments.
+    options, args = argparser.parse_known_args(cmdline_args)
+
+    # Check remaining args, which should be pattern and/or files.
+    for arg in args:
+        # Non-strings are an error.
+        if not isinstance(arg, str):
+            argparser.error("non-string argument: %s" % arg)
+
+        # Any options left in args are an error.
+        if arg.startswith('-'):
+            argparser.error("invalid option: %s" % arg)
+
+    return options, args, argparser
 
 
 HELP_TYPES_PREAMBLE = r'''
-The following types are supported.  Each type enables searching
-in several file extensions or name regexps.  --<type> includes
-the type in search and --no<type> excludes it.
+The following types are supported.  Each type enables searching in several
+file extensions or name regexps.  --<type> includes the type in search and
+--no<type> excludes it.
 '''.lstrip()
 
 
@@ -400,18 +427,18 @@ def _splice_comma_names(namelist):
     return newlist
 
 
-class PssOptionParser(optparse.OptionParser):
-    """Option parser that separates using --version from using invalid options.
-
-       By default optparse uses SystemExit with both. This parser uses custom
-       VersionPrinted exception with --version.
+class PssArgumentParser(argparse.ArgumentParser):
+    """Argument parser that allows more flexibility when specifying options
+       in an option file.
     """
 
-    def print_version(self, file=None):
-        optparse.OptionParser.print_version(self, file)
-        raise VersionPrinted()
-
-
-class VersionPrinted(Exception):
-    pass
-
+    def convert_arg_line_to_args(self, line):
+        if not line or line.startswith('#'):
+            # Blank line or comment.
+            return []
+        elif ' ' in line:
+            # Option + argument (with possible spaces in it).
+            return line.split(' ', 1)
+        else:
+            # Option.
+            return [line]

--- a/test/test_pssmain.py
+++ b/test/test_pssmain.py
@@ -401,6 +401,14 @@ class TestPssMain(unittest.TestCase):
                                 'testdir3/crnewlines.txt', [('MATCH', (1, [(10, 14)]))])
                          ))
 
+    def test_options_from_file(self):
+        confdir = path_to_testdir('config_files')
+        configfile = os.path.join(confdir, "test_pssmain.cfg")
+        self._run_main(['@' + configfile])
+        self.assertFoundFiles(self.of,
+                ['testdir1/filea.c', 'testdir1/filea.h',
+                'testdir1/subdir1/filey.c', 'testdir1/subdir1/filez.c'])
+
     def _run_main(self, args, dir=None, output_formatter=None, expected_rc=0):
         rc = main(
             argv=[''] + args + [dir or self.testdir1],

--- a/test/testdirs/config_files/test_pssmain.cfg
+++ b/test/testdirs/config_files/test_pssmain.cfg
@@ -1,0 +1,5 @@
+# Test getting options from a config file.
+
+# These are the same options as the 'test_only_find_files_f' test.
+--cc
+-f


### PR DESCRIPTION
Changes:

- use argparse instead of optparse
- allow options in @-style option files
- document @-style options in program help message
- add simple unit test
- remove VersionPrinted exception (no longer required)

The docs mention that pss support py2.6, but tox tests don't test it.  If you accept this patch and want to keep py2.6 support, you could add 'argparse-safe' to the dependency list (which would install it only if running py2.6).

Cheers,

Glenn